### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 # Use wildcards as well
 #*~
 #*.swp
+*.vtu
+*system.txt
 
 # Can also ignore all directories and files in a directory.
 #tmp/**/*


### PR DESCRIPTION
added wild card to stop uploading paraview VTU results and energy files. These should not be uploaded.